### PR TITLE
add line height property for zoom in and out buttons

### DIFF
--- a/dist/leaflet.zoomhome.css
+++ b/dist/leaflet.zoomhome.css
@@ -5,4 +5,5 @@
 a.leaflet-control-zoomhome-in,
 a.leaflet-control-zoomhome-out {
   font-size: 1.5em;
+  line-height: 26px;
 }


### PR DESCRIPTION
The line-height property is what actually fixes the zoom in and out buttons moving on the hover event.

Sorry for missing it in the previous PR.
