### PR TITLE
Feature request: Ability to modify homeCoordinates after init #3

### DIFF
--- a/dist/leaflet.zoomhome.js
+++ b/dist/leaflet.zoomhome.js
@@ -53,6 +53,11 @@
             this.setHomeZoom();
         },
 
+        setHomeBounds: function (bounds) {
+            this.options.homeZoom = map.getBoundsZoom(bounds);
+            this.options.homeCoordinates = bounds.getCenter();
+        },
+
         setHomeCoordinates: function (coordinates) {
             if (coordinates === undefined) {
                 this.options.homeCoordinates = this._map.getCenter();

--- a/dist/leaflet.zoomhome.js
+++ b/dist/leaflet.zoomhome.js
@@ -49,12 +49,12 @@
         },
 
         resetHome: function () {
-            setHomeCoordinates();
-            setHomeZoom();
+            this.setHomeCoordinates();
+            this.setHomeZoom();
         },
 
         setHomeCoordinates: function (coordinates) {
-            if (coordinates === null) {
+            if (coordinates === undefined) {
                 this.options.homeCoordinates = this._map.getCenter();
             }
             else
@@ -64,7 +64,7 @@
         },
 
         setHomeZoom: function (zoom) {
-            if (zoom === null) {
+            if (zoom === undefined) {
                 this.options.homeZoom = this._map.getZoom();
             }
             else

--- a/dist/leaflet.zoomhome.js
+++ b/dist/leaflet.zoomhome.js
@@ -54,7 +54,7 @@
         },
 
         setHomeBounds: function (bounds) {
-            this.options.homeZoom = map.getBoundsZoom(bounds);
+            this.options.homeZoom = this._map.getBoundsZoom(bounds);
             this.options.homeCoordinates = bounds.getCenter();
         },
 

--- a/dist/leaflet.zoomhome.js
+++ b/dist/leaflet.zoomhome.js
@@ -48,6 +48,31 @@
             return container;
         },
 
+        resetHome: function () {
+            setHomeCoordinates();
+            setHomeZoom();
+        },
+
+        setHomeCoordinates: function (coordinates) {
+            if (coordinates === null) {
+                this.options.homeCoordinates = this._map.getCenter();
+            }
+            else
+            {
+                this.options.homeCoordinates = coordinates;
+            }
+        },
+
+        setHomeZoom: function (zoom) {
+            if (zoom === null) {
+                this.options.homeZoom = this._map.getZoom();
+            }
+            else
+            {
+                this.options.homeZoom = zoom;
+            }
+        },
+
         _zoomHome: function (e) {
             //jshint unused:false
             this._map.setView(this.options.homeCoordinates, this.options.homeZoom);


### PR DESCRIPTION
I needed this functionality and noticed there was an outstanding issue for it.  I added the functionality and present it to you here.

There are three new method

- resetHome - Sets the centre and zoom based on the current position.
- setHomeCoordinates - Sets the map centre to supplied coordinates or uses the current position if not supplied.
- setHomeZoom - Sets the map zoom level to supplied zoom or uses the current zoom if not supplied.

Seems to work OK for me.  Hopefully it will be of use to others.